### PR TITLE
 Fix space issue in AntStructure.DTDPrinter

### DIFF
--- a/src/main/org/apache/tools/ant/taskdefs/AntStructure.java
+++ b/src/main/org/apache/tools/ant/taskdefs/AntStructure.java
@@ -324,7 +324,7 @@ public class AntStructure extends Task {
                             || !areNmtokens(values)) {
                             sb.append("CDATA ");
                         } else {
-                            sb.append(Stream.of(values).collect(joinAlts));
+                            sb.append(Stream.of(values).collect(joinAlts)).append(" ");
                         }
                     } catch (final InstantiationException | IllegalAccessException ie) {
                         sb.append("CDATA ");


### PR DESCRIPTION
Task AntStructure renders a project DTD. In AntStructure class DTDPrinter, line 327, a single statement is used to concatenate a list of enumerated values which are valid for an attribute. The list is enclosed in parentheses. At line 348 the string "#IMPLIED" is appended to all attribute definitions regardless of type. For other types like Boolean and CDATA, a space is appended. Not for these enumerations. This results in a DTD validation error. Ref [XERCES definition](https://xerces.apache.org/xerces-j/apiDocs/org/apache/xerces/utils/XMLMessages.html#MSG_SPACE_REQUIRED_BEFORE_DEFAULTDECL_IN_ATTDEF)

The full message displayed in VSCode may be different from elsewhere:

    White space is required before the attribute default in the declaration
    of attribute "x" for element "y". 
    xml(MSG_SPACE_REQUIRED_BEFORE_DEFAULTDECL_IN_ATTDEF)

This simple one-line change appends the space character required to avoid that error.

**Note:** This should not be modified into a change on the `joinAlts` Collector which surrounds values in parentheses. That Collector is used elsewhere where regex syntax is applied immediately after. See line 298. That asterisk cannot be separated from the values with a space. The space must only be applied to line 327.